### PR TITLE
Add GPU purchase module scaffolding

### DIFF
--- a/autoops/settings.py
+++ b/autoops/settings.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = [
     'release',
     'dockerops',
     'k8sops',
+    'gpuops',
     'xadmin',
     'crispy_forms',
     'reversion',

--- a/autoops/urls.py
+++ b/autoops/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path('library/', include('library.urls', namespace="library",), ),
     path('docker/', include('dockerops.urls', namespace="dockerops",), ),
     path('k8s/', include('k8sops.urls', namespace="k8sops",), ),
+    path('gpu/', include('gpuops.urls', namespace="gpuops",), ),
     path('upload/',  AssetUpload.as_view()),
     path('ueditor/',include('DjangoUeditor.urls' )),
     path('release/', include('release.urls', namespace="release")),

--- a/gpuops/adminx.py
+++ b/gpuops/adminx.py
@@ -1,0 +1,32 @@
+import xadmin
+
+from .models import GpuAllocation, GpuOffer, GpuOrder, GpuUsageRecord
+
+
+@xadmin.sites.register(GpuOffer)
+class GpuOfferAdmin(object):
+    list_display = ['name', 'gpu_model', 'gpu_memory_gb', 'hourly_price', 'is_active', 'ctime']
+    search_fields = ['name', 'gpu_model']
+    list_filter = ['gpu_model', 'is_active']
+
+
+@xadmin.sites.register(GpuOrder)
+class GpuOrderAdmin(object):
+    list_display = ['user', 'offer', 'hours', 'total_price', 'status', 'ctime']
+    search_fields = ['user__username', 'offer__name']
+    list_filter = ['status', 'offer']
+
+
+@xadmin.sites.register(GpuAllocation)
+class GpuAllocationAdmin(object):
+    list_display = ['order', 'container_id', 'gpu_uuid', 'status', 'bound_at', 'released_at']
+    search_fields = ['order__user__username', 'container_id', 'gpu_uuid']
+    list_filter = ['status']
+
+
+@xadmin.sites.register(GpuUsageRecord)
+class GpuUsageRecordAdmin(object):
+    list_display = ['order', 'start_at', 'end_at', 'billed_hours', 'ctime']
+    search_fields = ['order__user__username']
+    list_filter = ['order']
+

--- a/gpuops/models.py
+++ b/gpuops/models.py
@@ -1,0 +1,102 @@
+from decimal import Decimal
+
+from django.conf import settings
+from django.db import models
+
+
+class GpuOffer(models.Model):
+    name = models.CharField(max_length=128, verbose_name='套餐名称')
+    gpu_model = models.CharField(max_length=64, verbose_name='GPU型号')
+    gpu_memory_gb = models.PositiveIntegerField(verbose_name='显存(GiB)')
+    hourly_price = models.DecimalField(max_digits=10, decimal_places=2, verbose_name='单价(元/小时)')
+    is_active = models.BooleanField(default=True, verbose_name='是否上架')
+    description = models.TextField(blank=True, null=True, verbose_name='描述')
+    ctime = models.DateTimeField(auto_now_add=True, null=True, verbose_name='创建时间', blank=True)
+    utime = models.DateTimeField(auto_now=True, null=True, verbose_name='更新时间', blank=True)
+
+    class Meta:
+        db_table = 'gpu_offer'
+        verbose_name = 'GPU套餐'
+        verbose_name_plural = 'GPU套餐'
+
+    def __str__(self):
+        return self.name
+
+
+class GpuOrder(models.Model):
+    STATUS_PENDING = 'pending'
+    STATUS_PAID = 'paid'
+    STATUS_ACTIVE = 'active'
+    STATUS_FINISHED = 'finished'
+    STATUS_CANCELED = 'canceled'
+
+    STATUS_CHOICES = (
+        (STATUS_PENDING, '待支付'),
+        (STATUS_PAID, '已支付'),
+        (STATUS_ACTIVE, '使用中'),
+        (STATUS_FINISHED, '已结束'),
+        (STATUS_CANCELED, '已取消'),
+    )
+
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, verbose_name='购买用户')
+    offer = models.ForeignKey(GpuOffer, on_delete=models.PROTECT, verbose_name='套餐')
+    hours = models.PositiveIntegerField(verbose_name='购买时长(小时)')
+    total_price = models.DecimalField(max_digits=12, decimal_places=2, verbose_name='订单金额')
+    status = models.CharField(max_length=16, choices=STATUS_CHOICES, default=STATUS_PENDING, verbose_name='订单状态')
+    paid_at = models.DateTimeField(blank=True, null=True, verbose_name='支付时间')
+    start_at = models.DateTimeField(blank=True, null=True, verbose_name='开始时间')
+    end_at = models.DateTimeField(blank=True, null=True, verbose_name='结束时间')
+    ctime = models.DateTimeField(auto_now_add=True, null=True, verbose_name='创建时间', blank=True)
+    utime = models.DateTimeField(auto_now=True, null=True, verbose_name='更新时间', blank=True)
+
+    class Meta:
+        db_table = 'gpu_order'
+        verbose_name = 'GPU订单'
+        verbose_name_plural = 'GPU订单'
+
+    def __str__(self):
+        return f"{self.user}-{self.offer}-{self.ctime}"
+
+    @classmethod
+    def calculate_total(cls, offer, hours):
+        return (offer.hourly_price * Decimal(hours)).quantize(Decimal('0.01'))
+
+
+class GpuAllocation(models.Model):
+    STATUS_PENDING = 'pending'
+    STATUS_BOUND = 'bound'
+    STATUS_RELEASED = 'released'
+
+    STATUS_CHOICES = (
+        (STATUS_PENDING, '待分配'),
+        (STATUS_BOUND, '已分配'),
+        (STATUS_RELEASED, '已释放'),
+    )
+
+    order = models.OneToOneField(GpuOrder, on_delete=models.CASCADE, verbose_name='订单')
+    container_id = models.CharField(max_length=128, blank=True, null=True, verbose_name='容器ID')
+    gpu_uuid = models.CharField(max_length=128, blank=True, null=True, verbose_name='GPU UUID')
+    status = models.CharField(max_length=16, choices=STATUS_CHOICES, default=STATUS_PENDING, verbose_name='分配状态')
+    bound_at = models.DateTimeField(blank=True, null=True, verbose_name='分配时间')
+    released_at = models.DateTimeField(blank=True, null=True, verbose_name='释放时间')
+    ctime = models.DateTimeField(auto_now_add=True, null=True, verbose_name='创建时间', blank=True)
+    utime = models.DateTimeField(auto_now=True, null=True, verbose_name='更新时间', blank=True)
+
+    class Meta:
+        db_table = 'gpu_allocation'
+        verbose_name = 'GPU分配'
+        verbose_name_plural = 'GPU分配'
+
+
+class GpuUsageRecord(models.Model):
+    order = models.ForeignKey(GpuOrder, on_delete=models.CASCADE, verbose_name='订单')
+    start_at = models.DateTimeField(verbose_name='开始时间')
+    end_at = models.DateTimeField(blank=True, null=True, verbose_name='结束时间')
+    billed_hours = models.DecimalField(max_digits=10, decimal_places=2, verbose_name='计费时长(小时)')
+    ctime = models.DateTimeField(auto_now_add=True, null=True, verbose_name='创建时间', blank=True)
+
+    class Meta:
+        db_table = 'gpu_usage_record'
+        verbose_name = 'GPU用量记录'
+        verbose_name_plural = 'GPU用量记录'
+

--- a/gpuops/templates/gpuops/offer-list.html
+++ b/gpuops/templates/gpuops/offer-list.html
@@ -1,0 +1,77 @@
+{% extends "base.html" %}
+
+{% block title %}GPU 购买{% endblock %}
+
+{% block page-content %}
+
+    <div class="row wrapper border-bottom white-bg page-heading">
+        <div class="col-lg-10">
+            <h2>GPU 购买</h2>
+            <ol class="breadcrumb">
+                <li>
+                    <a href="/index.html">主页</a>
+                </li>
+                <li>
+                    <a>GPU 资源</a>
+                </li>
+                <li class="active">
+                    <strong>购买套餐</strong>
+                </li>
+            </ol>
+        </div>
+    </div>
+
+    <div class="wrapper wrapper-content animated fadeInRight">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="ibox float-e-margins">
+                    <div class="ibox-title">
+                        <h5>可购买套餐</h5>
+                    </div>
+                    <div class="ibox-content">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-bordered table-hover">
+                                <thead>
+                                <tr>
+                                    <th>套餐名称</th>
+                                    <th>GPU 型号</th>
+                                    <th>显存(GiB)</th>
+                                    <th>单价(元/小时)</th>
+                                    <th>购买时长(小时)</th>
+                                    <th>动作</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {% for offer in offers %}
+                                    <tr>
+                                        <td>{{ offer.name }}</td>
+                                        <td>{{ offer.gpu_model }}</td>
+                                        <td>{{ offer.gpu_memory_gb }}</td>
+                                        <td>{{ offer.hourly_price }}</td>
+                                        <td>
+                                            <input type="number" name="hours" class="form-control" min="1" value="1"
+                                                   form="order-form-{{ offer.id }}">
+                                        </td>
+                                        <td>
+                                            <form method="post" action="{% url 'gpuops:offer_list' %}"
+                                                  id="order-form-{{ offer.id }}" class="form-inline">
+                                                {% csrf_token %}
+                                                <input type="hidden" name="offer_id" value="{{ offer.id }}">
+                                                <button type="submit" class="btn btn-primary btn-sm">创建订单</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                {% empty %}
+                                    <tr>
+                                        <td colspan="6" class="text-center">暂无可用套餐</td>
+                                    </tr>
+                                {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/gpuops/templates/gpuops/order-list.html
+++ b/gpuops/templates/gpuops/order-list.html
@@ -1,0 +1,79 @@
+{% extends "base.html" %}
+
+{% block title %}GPU 订单{% endblock %}
+
+{% block page-content %}
+
+    <div class="row wrapper border-bottom white-bg page-heading">
+        <div class="col-lg-10">
+            <h2>GPU 订单</h2>
+            <ol class="breadcrumb">
+                <li>
+                    <a href="/index.html">主页</a>
+                </li>
+                <li>
+                    <a>GPU 资源</a>
+                </li>
+                <li class="active">
+                    <strong>订单列表</strong>
+                </li>
+            </ol>
+        </div>
+    </div>
+
+    <div class="wrapper wrapper-content animated fadeInRight">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="ibox float-e-margins">
+                    <div class="ibox-title">
+                        <h5>我的订单</h5>
+                    </div>
+                    <div class="ibox-content">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-bordered table-hover">
+                                <thead>
+                                <tr>
+                                    <th>订单号</th>
+                                    <th>套餐</th>
+                                    <th>时长(小时)</th>
+                                    <th>金额(元)</th>
+                                    <th>状态</th>
+                                    <th>创建时间</th>
+                                    <th>动作</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {% for order in orders %}
+                                    <tr>
+                                        <td>{{ order.id }}</td>
+                                        <td>{{ order.offer.name }}</td>
+                                        <td>{{ order.hours }}</td>
+                                        <td>{{ order.total_price }}</td>
+                                        <td>{{ order.get_status_display }}</td>
+                                        <td>{{ order.ctime }}</td>
+                                        <td>
+                                            {% if order.status == 'pending' %}
+                                                <form method="post" action="{% url 'gpuops:order_activate' order_id=order.id %}">
+                                                    {% csrf_token %}
+                                                    <button type="submit" class="btn btn-primary btn-xs">立即开通</button>
+                                                </form>
+                                            {% else %}
+                                                <span class="text-muted">-</span>
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                {% empty %}
+                                    <tr>
+                                        <td colspan="7" class="text-center">暂无订单</td>
+                                    </tr>
+                                {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+

--- a/gpuops/urls.py
+++ b/gpuops/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path
+
+from .views import GpuOfferList, GpuOrderActivate, GpuOrderList
+
+app_name = 'gpuops'
+
+urlpatterns = [
+    path('offers/', GpuOfferList.as_view(), name='offer_list'),
+    path('orders/', GpuOrderList.as_view(), name='order_list'),
+    path('orders/<int:order_id>/activate/', GpuOrderActivate.as_view(), name='order_activate'),
+]
+

--- a/gpuops/views.py
+++ b/gpuops/views.py
@@ -1,0 +1,85 @@
+from datetime import timedelta
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404, redirect, render
+from django.utils import timezone
+from django.utils.decorators import method_decorator
+from django.views import View
+
+from .models import GpuAllocation, GpuOffer, GpuOrder
+
+
+@method_decorator(login_required, name='dispatch')
+class GpuOfferList(View):
+    template_name = 'gpuops/offer-list.html'
+
+    def get(self, request):
+        offers = GpuOffer.objects.filter(is_active=True).order_by('hourly_price')
+        context = {
+            'gpu_active': 'active',
+            'gpu_offer_active': 'active',
+            'offers': offers,
+        }
+        return render(request, self.template_name, context)
+
+    def post(self, request):
+        offer_id = request.POST.get('offer_id')
+        hours = request.POST.get('hours')
+        if not offer_id or not hours:
+            messages.error(request, '请选择套餐并填写购买时长。')
+            return redirect('gpuops:offer_list')
+
+        try:
+            hours_value = int(hours)
+        except ValueError:
+            messages.error(request, '购买时长必须为整数。')
+            return redirect('gpuops:offer_list')
+
+        if hours_value <= 0:
+            messages.error(request, '购买时长必须大于0。')
+            return redirect('gpuops:offer_list')
+
+        offer = get_object_or_404(GpuOffer, pk=offer_id, is_active=True)
+        total_price = GpuOrder.calculate_total(offer, hours_value)
+        order = GpuOrder.objects.create(
+            user=request.user,
+            offer=offer,
+            hours=hours_value,
+            total_price=total_price,
+            status=GpuOrder.STATUS_PENDING,
+        )
+        GpuAllocation.objects.create(order=order)
+        messages.success(request, '订单已创建，请在订单列表中完成支付/开通。')
+        return redirect('gpuops:order_list')
+
+
+@method_decorator(login_required, name='dispatch')
+class GpuOrderList(View):
+    template_name = 'gpuops/order-list.html'
+
+    def get(self, request):
+        orders = GpuOrder.objects.filter(user=request.user).select_related('offer').order_by('-ctime')
+        context = {
+            'gpu_active': 'active',
+            'gpu_order_active': 'active',
+            'orders': orders,
+        }
+        return render(request, self.template_name, context)
+
+
+@method_decorator(login_required, name='dispatch')
+class GpuOrderActivate(View):
+    def post(self, request, order_id):
+        order = get_object_or_404(GpuOrder, pk=order_id, user=request.user)
+        if order.status != GpuOrder.STATUS_PENDING:
+            messages.info(request, '当前订单状态无法激活。')
+            return redirect('gpuops:order_list')
+
+        order.status = GpuOrder.STATUS_ACTIVE
+        order.paid_at = timezone.now()
+        order.start_at = order.paid_at
+        order.end_at = order.start_at + timedelta(hours=order.hours)
+        order.save(update_fields=['status', 'paid_at', 'start_at', 'end_at', 'utime'])
+        messages.success(request, '订单已激活，GPU 使用时长已开始计费。')
+        return redirect('gpuops:order_list')

--- a/templates/_nav.html
+++ b/templates/_nav.html
@@ -84,6 +84,15 @@
                 </ul>
             </li>
 
+            <li class="{{ gpu_active }}">
+                <a href="#"><i class="fa fa-sliders"></i> <span class="nav-label">GPU 资源</span>
+                    <span class="fa arrow"> </span></a>
+                <ul class="nav nav-second-level">
+                    <li class="{{ gpu_offer_active }}"><a href="{% url    'gpuops:offer_list' %}">购买套餐</a></li>
+                    <li class="{{ gpu_order_active }}"><a href="{% url    'gpuops:order_list' %}">我的订单</a></li>
+                </ul>
+            </li>
+
 
             <li class="{{ library_active }}">
                 <a href="#"><i class="fa fa-y-combinator-square"></i> <span class="nav-label">技术文档</span>


### PR DESCRIPTION
### Motivation

- Provide a lightweight GPU purchase/order workflow so users can browse GPU offers, create orders and activate purchased time. 
- Integrate this capability into the existing UI and xadmin so operators can manage offers, orders and allocations.

### Description

- Add a new `gpuops` app with data models in `gpuops/models.py` for `GpuOffer`, `GpuOrder`, `GpuAllocation` and `GpuUsageRecord` to represent offers, orders, allocations and usage records. 
- Implement views and routes in `gpuops/views.py` and `gpuops/urls.py` to list offers, create orders and activate orders, and use `timedelta` to compute `end_at` for activated orders. 
- Add templates `gpuops/templates/gpuops/offer-list.html` and `gpuops/templates/gpuops/order-list.html` to render the purchase and order UIs and change the offer form to use per-offer form IDs for correct submission. 
- Register GPU models in `gpuops/adminx.py` for xadmin and wire the app into the project by adding `'gpuops'` to `INSTALLED_APPS`, adding the `path('gpu/', include('gpuops.urls', ...))` route in `autoops/urls.py`, and adding sidebar entries in `templates/_nav.html`.

### Testing

- Attempted to verify runtime by importing Django with `python - <<'PY'` to check `django.get_version()`, but it failed with `ModuleNotFoundError: No module named 'django'`, so the application was not started and runtime tests were not executed. 
- Files were added and committed successfully (commit message: `Add GPU purchase module scaffolding`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982c4a324688320b4081624d4c86eab)